### PR TITLE
Update to UBI9 to support latest oc-mirror which requires glibc 2.32+

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,10 +1,10 @@
-FROM registry.access.redhat.com/ubi8/python-311:latest
+FROM registry.access.redhat.com/ubi9/python-311:latest
 
 ENV PYTHONPATH=/opt/app-root/src:$PYTHONPATH
 
 USER root
 
-RUN yum install --disablerepo=* --enablerepo=ubi-8-appstream-rpms --enablerepo=ubi-8-baseos-rpms -y \
+RUN yum install --disablerepo=* --enablerepo=ubi-9-appstream-rpms --enablerepo=ubi-9-baseos-rpms -y \
         yum-utils \
     && rm -rf /var/cache/yum
 


### PR DESCRIPTION
ocp4-disconnected currently fails against the latest openshift during oc-mirror due to incompatibility with the glibc 2.28 found in RHEL 8.9 (and thus UBI8). Openshift 4.15 requires glibc 2.32, 2.33, or 2.34.

There is a UBI9 python311 image which should ensure a high level of compatibility. Testing with buildah / podman on RHEL9 did not uncover any issues.